### PR TITLE
Use newer api version for `ava-fast-check`

### DIFF
--- a/test-ava/example.spec.js
+++ b/test-ava/example.spec.js
@@ -4,14 +4,14 @@ import { expect } from 'chai';
 ///*bug*/ const contains = (pattern, text) => text.substr(1).indexOf(pattern) !== -1;
 const contains = (pattern, text) => text.indexOf(pattern) !== -1;
 
-testProp('The concatenation of a, b and c always contains b', [fc.string(), fc.string(), fc.string()], (a, b, c) => {
-  return contains(b, a + b + c);
+testProp('The concatenation of a, b and c always contains b', [fc.string(), fc.string(), fc.string()], (t, a, b, c) => {
+  t.true(contains(b, a + b + c));
 });
 
 testProp(
   'The concatenation of a, b and c always contains b (with expect)',
   [fc.string(), fc.string(), fc.string()],
-  (a, b, c) => {
+  (t, a, b, c) => {
     expect(contains(b, a + b + c)).to.be.true;
   }
 );


### PR DESCRIPTION
The `ava-fast-check` library now provides the `t` context argument to each of the tests as the first argument.

From their npm page:

> ```js
> import { testProp, fc } from 'ava-fast-check';
> 
> // for all a, b, c strings
> // b is a substring of a + b + c
> testProp('should detect the substring', [fc.string(), fc.string(), fc.string()], (t, a, b, c) => {
>   t.true((a + b + c).includes(b));
> });
> ```
>
> The property is passed [AVA's t argument](https://github.com/avajs/ava/blob/main/docs/02-execution-context.md#execution-context-t-argument) for its first parameter, and the value of each arbitrary for the current test case for the rest of the parameters.